### PR TITLE
add documentation of how to use library in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,60 @@
 [![Build Status](https://travis-ci.org/persiancal/android-sdk.svg?branch=master)](https://travis-ci.org/persiancal/android-sdk)
 [![](https://jitpack.io/v/persiancal/android-sdk.svg)](https://jitpack.io/#persiancal/android-sdk)
 
+# Setup
+## 1. Provide the gradle dependency
+Add it in your root build.gradle at the end of repositories:
+```gradle
+allprojects {
+	repositories {
+		...
+		maven { url "https://jitpack.io" }
+	}
+}
+```
+Add the dependency:
+```gradle
+dependencies {
+	implementation 'com.github.persiancal:android-sdk:0.1.1'
+}
+```
+
+## 2. Add codes
+
+add INTERNET permission to android manifest
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+implement init function of RemoteClandarEvents in application class
+```kotlin
+override fun onCreate() {
+        super.onCreate()
+        ...
+        RemoteCalendarEvents
+            .addCalendar(CalendarType.JALALI)
+            .addCalendar(CalendarType.HIJRI)
+            .addCalendar(CalendarType.GREGORIAN)
+            .init(this)
+        ...
+}
+```
+You can add each type of calenders that want
+
+there is three function for getting calendar events
+```kotlin
+- getJalaliEvents(dayOfMonth: Int, month: Int): MutableList<RemoteJalaliEventsDb>?
+- getHijriEvents(dayOfMonth: Int, month: Int): MutableList<RemoteHijriEventsDb>?
+- getGregorianEvents(dayOfMonth: Int, month: Int): MutableList<RemoteGregorianEventsDb>?
+```
+After init RemoteCalendarEvents you can access instance of it everywhere:
+```kotlin
+RemoteCalendarEvents.getInstance()
+```
+for example we want `Jalali` events of `month=2` & `dayOfMonth=1`
+```kotlin
+val jalaliEvents= RemoteCalendarEvents.getInstance().getJalaliEvents(1,2)
+```
+
 **Requirements**
 - Android Studio 3.5.1
 - JDK 8


### PR DESCRIPTION
close #5 close #4 
- add the library to jitpack.io
- add document of who to use the remote-sdk library in another app