### PR TITLE
Fix spelling warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,6 @@ output.json
 # Replacement of .externalNativeBuild directories introduced
 # with Android Studio 3.5.
 .cxx/
-/.idea/
+.idea/*
+!.idea/dictionaries/
 # End of https://www.gitignore.io/api/android

--- a/.idea/dictionaries/persianCal.xml
+++ b/.idea/dictionaries/persianCal.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="persianCal">
+    <words>
+      <w>hijri</w>
+      <w>jalali</w>
+    </words>
+  </dictionary>
+</component>


### PR DESCRIPTION
Add to dictionary option of the IDE creates a user-specific
dictionary file that is not reusable by the team
So I created a general dictionary file
and added the "hijri" and "jalali" words to that.
You need to restart the IDE for changes to take effect.

Excluding just the persianCal.xml in the gitignore didn't work so I excluded the whole dictionary folder.